### PR TITLE
DM-35455: Create a composite action for building and publishing to PyPI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'thursday'
+      time: '09:00'
+      timezone: America/Toronto

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,25 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+
+  pre-commit:
+    name: Lint with pre-commit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install pre-commit
+        run: |
+          pip install --upgrade pre-commit
+          pre-commit install
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,13 @@
+name: Update Major Version Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  update-majorver:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-yaml
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.17.0
+    hooks:
+      - id: check-github-workflows
+      - id: check-dependabot
+      # Schema is not compatible with a composite action
+      # - id: check-github-actions

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 LSST SQuaRE
+Copyright (c) 2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: init
+init:
+	pip install --upgrade pip pre-commit
+	pre-commit install

--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
+          python-version: "3.10"
 ```
 
 ## Inputs
 
 - `pypi-token` (string, required) an API token for PyPI.
-- `python-version` (string, optional) the Python version. Default is `3.10`.
+- `python-version` (string, required) the Python version.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,89 @@
 # build-and-publish-to-pypi
-A GitHub Actions workflow for building a Python package and publishing it to PyPI.
+
+This is a [composite GitHub Action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) for building a pure-Python package and publishing it to the [Python Package Index (PyPI)](https://pypi.org).
+
+This actions rolls into a single step two tasks that are commonly run together:
+
+1. Build a Python package's distribution, accomplished with the PyPA's [build](https://pypa-build.readthedocs.io/en/stable/index.html) tool.
+2. Upload the distribution to PyPI, using the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) action.
+
+Since this action uses the [build](https://pypa-build.readthedocs.io/en/stable/index.html) tool, any [PEP 517](https://peps.python.org/pep-0517/)-compatible packaging backend is supported, including [setuptools](https://setuptools.pypa.io/en/latest/).
+You can make your project PEP 517-compatible by adding a `project.toml` file and specifying the build backend in a `[build-system]` section ([see setuptools' tutorial on this](https://setuptools.pypa.io/en/latest/build_meta.html)).
+
+**However, building wheels for multiple platforms is not supported by this action.**
+If your package compiles extensions, you'll need to build your own multi-platform GitHub Actions job that builds a wheel on each platform.
+
+## Example usage
+
+```yaml
+name: Python CI
+
+"on":
+  push:
+    tags:
+      - "*"
+  pull_request: {}
+
+jobs:
+
+  pypi:
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Build and publish
+        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        with:
+          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
+```
+
+## Inputs
+
+- `pypi-token` (string, required) an API token for PyPI.
+- `python-version` (string, optional) the Python version. Default is `3.10`.
+
+## Outputs
+
+No outputs.
+
+## Usage tips
+
+### Using this action with job dependencies
+
+Typically, you'll want to run the PyPI upload _after_ doing any tests.
+In that case, add a `needs` field listing those other jobs:
+
+
+```yaml
+jobs:
+
+  lint: {}
+    # ...
+
+  test: {}
+    # ...
+
+  docs: {}
+    # ...
+
+  pypi:
+
+    runs-on: ubuntu-latest
+    needs: [lint, test, docs]
+```
+
+## Developer guide
+
+This repository provides a **composite** GitHub Action, a type of action that packages multiple regular actions into a single step.
+We do this to make the GitHub Actions of all our software projects more consistent and easier to maintain.
+[You can learn more about composite actions in the GitHub documentation.](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)
+
+Create new releases using the GitHub Releases UI and assign a tag with a [semantic version](https://semver.org), including a `v` prefix. Choose the semantic version based on compatibility for users of this workflow. If backwards compatibility is broken, bump the major version.
+
+When a release is made, a new major version tag (i.e. `v1`, `v2`) is also made or moved using [nowactions/update-majorver](https://github.com/marketplace/actions/update-major-version).
+We generally expect that most users will track these major version tags.

--- a/action.yaml
+++ b/action.yaml
@@ -8,8 +8,7 @@ inputs:
     required: true
   python-version:
     description: "Python version"
-    required: false
-    default: "3.10"
+    required: true
 runs:
   using: "composite"
   steps:

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,33 @@
+name: "Build and publish to PyPI"
+description: >
+  This composite action builds a Python package's distribution with the
+  PyPA's build tool (PEP517) and uploads it to PyPI.
+inputs:
+  pypi-token:
+    description: "Token for PyPI"
+    required: true
+  python-version:
+    description: "Python version"
+    required: false
+    default: "3.10"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Python install
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade build
+
+    - name: Build
+      run: python -m build
+
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ inputs.pypi-token }}


### PR DESCRIPTION
This PR sets up the repository as a GitHub [Composite Action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) that can be called as a regular action step either by other repo's GitHub Actions workflows or through reusable workflows.

This action specifically packages our common practices of building a Python package's distribution and publishing it to GitHub Actions, as described in the README docs.

To build the distribution, I'm now using the [build](https://pypa-build.readthedocs.io/en/stable/index.html) tool, which is the PEP 587 modernization of `python setup.py sdist bdist wheel`. This is actually new to me. To do the PyPI upload, I'm using [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish), which we've used previously.

I chose not to include `actions/checkout` in this composite action so that end-users could a) specify options for checking out the code, and b) easily run action steps before building and publishing, such as building/copying in assets or other random things.

A basic example of using this composite action:

```yaml
name: Python CI

"on":
  push:
    tags:
      - "*"
  pull_request: {}

jobs:

  pypi:

    runs-on: ubuntu-latest
    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')

    steps:
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0 # full history for setuptools_scm

      - name: Build and publish
        uses: lsst-sqre/build-and-publish-to-pypi@v1
        with:
          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
```