### PR TITLE
DM-35548: Shell parameter is needed for a run action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Python install
+      shell: bash
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade build


### PR DESCRIPTION
`run` actions in a composite action require a `shell` parameter. This provides that.