### PR TITLE
DM-35590: Add a dry-run mode with twine check

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ jobs:
 
 - `pypi-token` (string, required) an API token for PyPI.
 - `python-version` (string, required) the Python version.
+- `upload` (boolean, optional) a flag to enable PyPI uploads. Default is `true`.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ jobs:
 - `pypi-token` (string, required) an API token for PyPI.
 - `python-version` (string, required) the Python version.
 - `upload` (boolean, optional) a flag to enable PyPI uploads. Default is `true`.
+  If `false`, the action skips the upload to PyPI, but also runs additional pre-flight validation with [`twine check`](https://twine.readthedocs.io/en/stable/index.html#twine-check).
 
 ## Outputs
 
@@ -77,6 +78,40 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [lint, test, docs]
+```
+
+### Running in a dry-run
+
+You only want to publish to PyPI in a release event, which is typically for tag pushes.
+You can still run this action in a general pull request workflow, however, to test and validate the package build without uploading to PyPI.
+See how the `upload` parameter can be toggled off for non-release events:
+
+```yaml
+name: Python CI
+
+"on":
+  push:
+    tags:
+      - "*"
+  pull_request: {}
+
+jobs:
+
+  pypi:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Build and publish
+        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        with:
+          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
+          python-version: "3.10"
+          upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
 ```
 
 ## Developer guide

--- a/action.yaml
+++ b/action.yaml
@@ -27,11 +27,24 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade build
 
+    - name: Install twine for check
+      shell: bash
+      if: fromJSON(inputs.upload) == false
+      run: |
+        python -m pip install --upgrade twine
+
     - name: Build
+      shell: bash
       run: python -m build
 
+    - name: Check packaging
+      shell: bash
+      if: fromJSON(inputs.upload) == false
+      run: |
+        twine check dist/*
+
     - name: Publish
-      if: fromJSON(${{ inputs.upload }})
+      if: fromJSON(inputs.upload) == true
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,10 @@ inputs:
   python-version:
     description: "Python version"
     required: true
+  upload:
+    description: "Enable PyPI Uploads"
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -27,6 +31,7 @@ runs:
       run: python -m build
 
     - name: Publish
+      if: fromJSON(${{ inputs.upload }})
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__


### PR DESCRIPTION
The new `upload` input for the action defaults to `true`, but can be toggled to `false` to disable uploads to PyPI. When `upload` is `false`, the action runs an additional step with `twine check` to validate the distributions. Hence this action can be used pull request workflows to ensure that the package builds and has valid metadata.

An example of uploading to PyPI only for tag pushes:

```yaml
name: Python CI

"on":
  push:
    tags:
      - "*"
  pull_request: {}

jobs:

  pypi:

    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0 # full history for setuptools_scm

      - name: Build and publish
        uses: lsst-sqre/build-and-publish-to-pypi@v1
        with:
          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
          python-version: "3.10"
          upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
```