### PR TITLE
DM-39837: Adopt PyPI's trusted publisher program (for v2)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.17.0
+    rev: 0.23.2
     hooks:
       - id: check-github-workflows
       - id: check-dependabot

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright (c) 2022-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
           python-version: "3.11"
 ```
@@ -146,7 +146,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
           python-version: "3.11"
           upload: "false"
@@ -167,7 +167,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
           python-version: "3.11"
 ```
@@ -206,7 +206,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
-        uses: lsst-sqre/build-and-publish-to-pypi@v1
+        uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
           python-version: "3.11"
 ```

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ This is a [composite GitHub Action](https://docs.github.com/en/actions/creating-
 This actions rolls into a single step two tasks that are commonly run together:
 
 1. Build a Python package's distribution, accomplished with the PyPA's [build](https://pypa-build.readthedocs.io/en/stable/index.html) tool.
-2. Upload the distribution to PyPI, using the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) action.
+2. Upload the distribution to PyPI, using the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) action, using PyPI's [trusted publishers](https://docs.pypi.org/trusted-publishers/) mechanism. **New in v2: using trusted publishers is required. Use v1 for the legacy account token for PyPI.**
 
-Since this action uses the [build](https://pypa-build.readthedocs.io/en/stable/index.html) tool, any [PEP 517](https://peps.python.org/pep-0517/)-compatible packaging backend is supported, including [setuptools](https://setuptools.pypa.io/en/latest/).
-You can make your project PEP 517-compatible by adding a `project.toml` file and specifying the build backend in a `[build-system]` section ([see setuptools' tutorial on this](https://setuptools.pypa.io/en/latest/build_meta.html)).
-
-**However, building wheels for multiple platforms is not supported by this action.**
-If your package compiles extensions, you'll need to build your own multi-platform GitHub Actions job that builds a wheel on each platform.
+> **Note**
+> Since this action uses the [build](https://pypa-build.readthedocs.io/en/stable/index.html) tool, any [PEP 517](https://peps.python.org/pep-0517/)-compatible packaging backend is supported, including [setuptools](https://setuptools.pypa.io/en/latest/).
+> You can make your project PEP 517-compatible by adding a `project.toml` file and specifying the build backend in a `[build-system]` section ([see setuptools' tutorial on this](https://setuptools.pypa.io/en/latest/build_meta.html)).
+>
+> **However, building wheels for multiple platforms is not supported by this action.**
+> If your package compiles extensions, you'll need to build your own multi-platform GitHub Actions job that builds a wheel on each platform.
 
 ## Example usage
 
@@ -37,13 +38,11 @@ jobs:
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
-          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
           python-version: "3.10"
 ```
 
 ## Inputs
 
-- `pypi-token` (string, required) an API token for PyPI.
 - `python-version` (string, required) the Python version.
 - `upload` (boolean, optional) a flag to enable PyPI uploads. Default is `true`.
   If `false`, the action skips the upload to PyPI, but also runs additional pre-flight validation with [`twine check`](https://twine.readthedocs.io/en/stable/index.html#twine-check).
@@ -106,7 +105,6 @@ jobs:
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
-          pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
           python-version: "3.10"
           upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -3,9 +3,6 @@ description: >
   This composite action builds a Python package's distribution with the
   PyPA's build tool (PEP517) and uploads it to PyPI.
 inputs:
-  pypi-token:
-    description: "Token for PyPI"
-    required: true
   python-version:
     description: "Python version"
     required: true
@@ -53,6 +50,4 @@ runs:
       if: fromJSON(inputs.upload) == true
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ inputs.pypi-token }}
         packages-dir: ${{ inputs.working-directory }}/dist


### PR DESCRIPTION
This PR intends to create version 2 of this action by dropping the pypi-token input, and therefore rely exclusively on the OIDC authentication to PyPI. Repos that haven't upgraded yet can continue to use v1 for the time being.

The examples and documentation also include considerations for setting up a GitHub environment to secure the job that performs the upload, and, using GitHub Releases as the trigger rather than purely watching tag pushes.