### PR TITLE
Update Python version for linting to 3.13

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install pre-commit
         run: |


### PR DESCRIPTION
Update the Python version used in the GitHub Actions check for linting to 3.13.